### PR TITLE
FIXED Issue 69: Theme-box is now on the Home page header.

### DIFF
--- a/Website/Style/web/main_d485f_v1.css
+++ b/Website/Style/web/main_d485f_v1.css
@@ -133,7 +133,7 @@ li:not(:last-child) {
     z-index: 99999999;
     display: inline-block;
     margin-right: 1rem;
-    position: fixed;
+    /* position: fixed; */
     top: 50%;
     top: 50%;
     left: 2rem;

--- a/Website/Style/web/main_post_d485f_v1.css
+++ b/Website/Style/web/main_post_d485f_v1.css
@@ -179,7 +179,7 @@ th {
     z-index: 99999999;
     display: inline-block;
     margin-right: 1rem;
-    position: fixed;
+    /* position: fixed; */
     left: 2rem;
     top: 50%;
 }

--- a/index.html
+++ b/index.html
@@ -97,25 +97,27 @@
             </div>
             <div class="menu">
                 <div>
-                    <ol>
-                        <li><a href="/"><i class="bi bi-house-door"></i> Home</a></li>
-                        <li><a href="#"><i class="bi bi-bag-plus"></i> Tool</a></li>
-                        <li><a href="https://github.com/Diptenusarkar/html.org.in/"><i class="bi bi-github"></i> Edit
-                            </a>
-                        </li>
-                        <li><a href="https://github.com/sponsors/Diptenusarkar"><i class="bi bi-cash-stack"></i> Sponsor
-                            </a>
-                        </li>
-                        <li>
-                            <div class="theme__box">
-                                <select id="themeSwitcher">
-                                    <option value="">Select One</option>
-                                    <option value="theme-dark">Dark</option>
-                                    <option value="theme-light">Light</option>
-                                </select>
-                            </div>
-                        </li>
-                    </ol>
+                    <div>
+                        <ol>
+                            <li><a href="/"><i class="bi bi-house-door"></i> Home</a></li>
+                            <li><a href="#"><i class="bi bi-bag-plus"></i> Tool</a></li>
+                            <li><a href="https://github.com/Diptenusarkar/html.org.in/"><i class="bi bi-github"></i> Edit
+                                </a>
+                            </li>
+                            <li><a href="https://github.com/sponsors/Diptenusarkar"><i class="bi bi-cash-stack"></i> Sponsor
+                                </a>
+                            </li>
+                            <li>
+                                <div class="theme__box">
+                                    <select id="themeSwitcher">
+                                        <option value="">Select One</option>
+                                        <option value="theme-dark">Dark</option>
+                                        <option value="theme-light">Light</option>
+                                    </select>
+                                </div>
+                            </li>
+                        </ol>
+                    </div>
                 </div>
             </div>
         </nav>

--- a/index.html
+++ b/index.html
@@ -46,15 +46,15 @@
 </head>
 
 <body>
-    <div include-html="include/header.html" id="header_file"></div>
+    <!-- <div include-html="include/header.html" id="header_file"></div> -->
     <!-- <div include-html="include/themeSwitcher.html" id="themeSwitcher_file"></div> -->
-    <div class="theme__box">
+    <!-- <div class="theme__box">
         <select id="themeSwitcher">
             <option value="">Select One</option>
             <option value="theme-dark">Dark</option>
             <option value="theme-light">Light</option>
         </select>
-    </div>
+    </div> -->
     <!-- <header class="header">
         <nav class="nav">
             <a href="/" class="logo__top">HTML.ORG.IN</a>
@@ -86,6 +86,40 @@
             <option value="theme-light">Light</option>
         </select>
     </div> -->
+
+    <header class="header">      
+        <nav class="menu-wrap nav">
+            <a href="/" class="logo__top" style="color:#ff6d00;"><i class="bi bi-filetype-html"></i> HTML.ORG.IN </a>
+            <input type="checkbox" class="toggler">
+    
+            <div class="hamburger">
+                <div></div>
+            </div>
+            <div class="menu">
+                <div>
+                    <ol>
+                        <li><a href="/"><i class="bi bi-house-door"></i> Home</a></li>
+                        <li><a href="#"><i class="bi bi-bag-plus"></i> Tool</a></li>
+                        <li><a href="https://github.com/Diptenusarkar/html.org.in/"><i class="bi bi-github"></i> Edit
+                            </a>
+                        </li>
+                        <li><a href="https://github.com/sponsors/Diptenusarkar"><i class="bi bi-cash-stack"></i> Sponsor
+                            </a>
+                        </li>
+                        <li>
+                            <div class="theme__box">
+                                <select id="themeSwitcher">
+                                    <option value="">Select One</option>
+                                    <option value="theme-dark">Dark</option>
+                                    <option value="theme-light">Light</option>
+                                </select>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+        </nav>
+    </header>
 
     <main class="main">
         <section class="main__html-component">


### PR DESCRIPTION
## What does this PR do?
The theme-box has been moved to the header and no longer overlap the tutorial boxes, but the theme-box is still unique to the Home page.

## Related Issue
Resolves the primary problem described in Issue #69.

## Screenshots of changes made

### Home Page before changes  
![image](https://user-images.githubusercontent.com/69469270/203185159-8c2bc660-a7c7-4f22-97c7-e301d0005e5c.png)

### Home Page after changes  
![image](https://user-images.githubusercontent.com/69469270/203185197-3280b745-f9fe-4227-ba44-3e5d479fdebd.png)

## Description of code changes
Initially, I moved the theme-box's HTML from the Home page's `index.html` file to the `include\header.html` file, as a list item within the `<div class="menu">` element.  
This resulted in the theme-box appearing on the header on each page. However, the theme-box lost the ability to actually change the website's theme. The functionality within `app.js` is not applied to the theme-box if the theme-box is included from a separate HTML file via the `include-html` attribute on an element (e.g. `<div include-html="include\header.html"></div>`).

So, I moved the HTML code from the `include\header.html` file into the Home page's `index.html` file and discarded the changes I made to the `header.html` file (as such, the `header.html` file does not have any changes committed to it).  
I tested this version and the theme-box appears on the header, thus it does not overlap tutorial boxes anymore (as described in issue #69) and it works correctly (being able to change the theme as intended).  

**Note that:** with this method, the theme-box only appears on the Home page and is not available on the individual tutorial pages.
